### PR TITLE
Normalize phone numbers in the database

### DIFF
--- a/flasquelistan/factory.py
+++ b/flasquelistan/factory.py
@@ -94,7 +94,7 @@ def populate_testdb():
         email='monty@python.tld',
         first_name='Monty',
         last_name='Python',
-        phone='070-1740605',
+        phone='+468-46500400',
         balance=10000,
         active=True,
     )
@@ -104,7 +104,7 @@ def populate_testdb():
         first_name='Rick',
         nickname='The Roll',
         last_name='Astley',
-        phone='+468-46500400',
+        phone='0710001122', # Invalid phone number
         balance=20050,
         active=True,
     )

--- a/flasquelistan/factory.py
+++ b/flasquelistan/factory.py
@@ -42,11 +42,13 @@ def create_app(config=None, instance_config=None):
 def register_blueprints(app):
     from flasquelistan.views import (auth, admin, quotes, serviceworker,
                                      strequelistan)
+    from flasquelistan import scripts
     app.register_blueprint(auth.mod)
     app.register_blueprint(admin.mod)
     app.register_blueprint(serviceworker.mod)
     app.register_blueprint(strequelistan.mod)
     app.register_blueprint(quotes.mod)
+    app.register_blueprint(scripts.mod)
 
 
 def register_cli(app):
@@ -92,7 +94,7 @@ def populate_testdb():
         email='monty@python.tld',
         first_name='Monty',
         last_name='Python',
-        phone='0710001122',
+        phone='070-1740605',
         balance=10000,
         active=True,
     )
@@ -102,7 +104,7 @@ def populate_testdb():
         first_name='Rick',
         nickname='The Roll',
         last_name='Astley',
-        phone='0713322110',
+        phone='+468-46500400',
         balance=20050,
         active=True,
     )
@@ -132,7 +134,7 @@ def populate_testdb():
         first_name='Malvina',
         last_name='Teknolog',
         nickname='Osqulda',
-        phone='074-345 32 10',
+        phone='',
         balance=-10000,
         active=True,
     )

--- a/flasquelistan/forms.py
+++ b/flasquelistan/forms.py
@@ -143,21 +143,6 @@ class UniqueEmailForm(flask_wtf.FlaskForm):
     ])
 
 
-class PhoneForm(flask_wtf.FlaskForm):
-    phone = html5_fields.TelField(
-        _l('Telefon'),
-        description=_l("Ett telefonnummer, med eller utan landskod.")
-    )
-
-    def validate_phone(form, field):
-        if not field.data:
-            # Empty/unset phone numbers are allowed.
-            return True
-        elif not util.format_phone_number(field.data, e164=True):
-            raise validators.ValidationError("Telefonnummret är ogiltigt.")
-        return True
-
-
 class PasswordForm(flask_wtf.FlaskForm):
     password = fields.PasswordField(
         _l('Lösenord'),
@@ -234,7 +219,7 @@ class VoidTransactionForm(flask_wtf.FlaskForm):
     transaction_id = fields.HiddenField()
 
 
-class EditUserForm(PhoneForm):
+class EditUserForm(flask_wtf.FlaskForm):
     nickname = fields.StringField(
         _l('Smeknamn'),
         description=_l("Något roligt."),
@@ -249,6 +234,12 @@ class EditUserForm(PhoneForm):
         validators=[
             validators.Optional()
         ]
+    )
+
+    phone = html5_fields.TelField(
+        _l('Telefon'),
+        description=_l("Ett telefonnummer. Landskod kan utelämnas för svenska"
+                       " nummer, men behövs för utländska nummer.")
     )
 
     body_mass = html5_fields.IntegerField(
@@ -305,7 +296,7 @@ class AddUserForm(UniqueEmailForm, FullEditUserForm):
     pass
 
 
-class RegistrationRequestForm(UniqueEmailForm, PhoneForm):
+class RegistrationRequestForm(UniqueEmailForm):
     first_name = fields.StringField(
         _l('Förnamn'),
         validators=[
@@ -319,6 +310,11 @@ class RegistrationRequestForm(UniqueEmailForm, PhoneForm):
             validators.InputRequired(),
             validators.Length(max=50)
         ],
+    )
+    phone = html5_fields.TelField(
+        _l('Telefon'),
+        description=_l("Ett telefonnummer. Landskod kan utelämnas för svenska"
+                       " nummer, men behövs för utländska nummer.")
     )
     message = fields.TextAreaField(_l('Meddelande till QM'))
 

--- a/flasquelistan/forms.py
+++ b/flasquelistan/forms.py
@@ -143,6 +143,21 @@ class UniqueEmailForm(flask_wtf.FlaskForm):
     ])
 
 
+class PhoneForm(flask_wtf.FlaskForm):
+    phone = html5_fields.TelField(
+        _l('Telefon'),
+        description=_l("Ett telefonnummer, med eller utan landskod.")
+    )
+
+    def validate_phone(form, field):
+        if not field.data:
+            # Empty/unset phone numbers are allowed.
+            return True
+        elif not util.format_phone_number(field.data, e164=True):
+            raise validators.ValidationError("Telefonnummret är ogiltigt.")
+        return True
+
+
 class PasswordForm(flask_wtf.FlaskForm):
     password = fields.PasswordField(
         _l('Lösenord'),
@@ -219,7 +234,7 @@ class VoidTransactionForm(flask_wtf.FlaskForm):
     transaction_id = fields.HiddenField()
 
 
-class EditUserForm(flask_wtf.FlaskForm):
+class EditUserForm(PhoneForm):
     nickname = fields.StringField(
         _l('Smeknamn'),
         description=_l("Något roligt."),
@@ -234,11 +249,6 @@ class EditUserForm(flask_wtf.FlaskForm):
         validators=[
             validators.Optional()
         ]
-    )
-
-    phone = html5_fields.TelField(
-        _l('Telefon'),
-        description=_l("Ett telefonnummer, med eller utan landskod.")
     )
 
     body_mass = html5_fields.IntegerField(
@@ -295,7 +305,7 @@ class AddUserForm(UniqueEmailForm, FullEditUserForm):
     pass
 
 
-class RegistrationRequestForm(UniqueEmailForm):
+class RegistrationRequestForm(UniqueEmailForm, PhoneForm):
     first_name = fields.StringField(
         _l('Förnamn'),
         validators=[
@@ -309,10 +319,6 @@ class RegistrationRequestForm(UniqueEmailForm):
             validators.InputRequired(),
             validators.Length(max=50)
         ],
-    )
-    phone = html5_fields.TelField(
-        _l('Telefon'),
-        description=_l("Ett telefonnummer, med eller utan landskod.")
     )
     message = fields.TextAreaField(_l('Meddelande till QM'))
 

--- a/flasquelistan/models.py
+++ b/flasquelistan/models.py
@@ -114,16 +114,13 @@ class User(flask_login.UserMixin, db.Model):
 
     @phone.setter
     def phone(self, phone):
-        """Set phone number, but normalize it first (if non-empty)."""
-        if not phone:
-            self._phone = phone
-            return
+        """Set phone number, but normalize it first if possible."""
 
         normalized = util.format_phone_number(phone, e164=True)
         if normalized:
             self._phone = normalized
         else:
-            raise AssertionError('The phone number is invalid.')
+            self._phone = phone
 
     def formatted_phone(self, e164=False):
         return util.format_phone_number(self.phone, e164)

--- a/flasquelistan/scripts/__init__.py
+++ b/flasquelistan/scripts/__init__.py
@@ -1,0 +1,9 @@
+from flask import Blueprint
+
+from . import normalize_phone_numbers
+
+mod = Blueprint('scripts', __name__)
+
+@mod.cli.command('normalize_phone_numbers')
+def normalize_phone_numbers_command():
+    normalize_phone_numbers.run()

--- a/flasquelistan/scripts/__init__.py
+++ b/flasquelistan/scripts/__init__.py
@@ -4,6 +4,7 @@ from . import normalize_phone_numbers
 
 mod = Blueprint('scripts', __name__)
 
+
 @mod.cli.command('normalize_phone_numbers')
 def normalize_phone_numbers_command():
     normalize_phone_numbers.run()

--- a/flasquelistan/scripts/normalize_phone_numbers.py
+++ b/flasquelistan/scripts/normalize_phone_numbers.py
@@ -1,0 +1,47 @@
+import click
+import sys
+
+from flasquelistan import models
+from flasquelistan.util import format_phone_number
+
+
+def run():
+    """Go through all users and update all phone numbers to be in the
+    E.164 phone number format. Please make sure to backup the database
+    before running this script."""
+
+    if not click.confirm("Have you taken a backup of the database?"):
+        click.echo("Please backup the database before running this script.")
+        sys.exit(1)
+
+    with models.db.session.begin():
+        for user in models.User.query.all():
+            current = user.phone
+
+            if not current:
+                click.echo(
+                    f"'{user.first_name} {user.last_name}' has no phone number.")
+                continue
+
+            normalized = format_phone_number(current, e164=True)
+            if not normalized:
+                click.echo(
+                    "Was not able to normalize the phone number of "
+                    f"'{user.first_name} {user.last_name}': '{current}'")
+            elif current == normalized:
+                click.echo(
+                    f"'{user.first_name} {user.last_name}' already has a "
+                    f"normalized phone number: '{user.phone}'")
+            else:
+                click.echo(
+                    f"Normalizing phone number of '{user.first_name} "
+                    f"{user.last_name}': "
+                    f"old: '{user.phone}', new: '{normalized}'.")
+                user.phone = normalized
+
+        if len(models.db.session.dirty) == 0:
+            click.echo("No changes to the database were performed.")
+        elif click.confirm("Do you want to commit the changes to the database?"):
+            models.db.session.commit()
+        else:
+            models.db.session.rollback()

--- a/flasquelistan/templates/show_profile.html
+++ b/flasquelistan/templates/show_profile.html
@@ -49,6 +49,9 @@
       <dd>
       {% if user.formatted_phone() %}
       <a href="tel:{{ user.formatted_phone(e164=True) }}">{{ user.formatted_phone() }}</a>
+      {% elif user == current_user or current_user.is_admin %}
+      {{ user.phone }}<br />
+      <em>{{ _("(varning: telefonnumret ser ogiltigt ut)") }}</em>
       {% else %}
       {{ user.phone }}
       {% endif %}

--- a/flasquelistan/util.py
+++ b/flasquelistan/util.py
@@ -9,6 +9,7 @@ from urllib.parse import urljoin, urlparse
 
 import flask
 import flask_uploads
+import phonenumbers
 import werkzeug
 from PIL import Image, ImageOps
 
@@ -134,3 +135,24 @@ def rotate_jpeg(filename):
     if 'exif' in img.info:
         rotated = ImageOps.exif_transpose(img)
         rotated.save(filename, exif=rotated.info.get('exif'))
+
+
+def format_phone_number(phone, e164=False):
+    """Returns formatted number or False if not a valid number."""
+    try:
+        # If no country code, assume Swedish
+        parsed = phonenumbers.parse(phone, 'SE')
+    except phonenumbers.phonenumberutil.NumberParseException:
+        return False
+
+    if not (phonenumbers.is_possible_number(parsed)
+            and phonenumbers.is_valid_number(parsed)):
+        return False
+
+    formatted = phonenumbers.format_number(
+        parsed,
+        phonenumbers.PhoneNumberFormat.E164 if e164
+        else phonenumbers.PhoneNumberFormat.INTERNATIONAL
+    )
+
+    return formatted

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -221,12 +221,19 @@ def test_user_model(app):
     models.db.session.commit()
 
     assert user.id > 0
+
+    # Valid phone numbers are automatically normalized.
     assert user.phone == '+46743453210'
+
+    # Invalid phone numbers are allowed as well (but not normalized).
+    invalid_example_number = '+4674-876 543 226 189 416 854 65'
+    user.phone = invalid_example_number
+    models.db.session.commit()
+    assert user.phone == invalid_example_number
 
     # Phone number is not required.
     user.phone = ''
     models.db.session.commit()
-
     assert user.phone == ''
 
 

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -214,13 +214,20 @@ def test_user_model(app):
         email='monty@python.tld',
         first_name='Monty',
         last_name='Python',
-        phone='0700011223',
+        phone='074-345 32 10',
     )
 
     models.db.session.add(user)
     models.db.session.commit()
 
     assert user.id > 0
+    assert user.phone == '+46743453210'
+
+    # Phone number is not required.
+    user.phone = ''
+    models.db.session.commit()
+
+    assert user.phone == ''
 
 
 def test_usertransaction_model(app):


### PR DESCRIPTION
Add form validation to ensure valid phone numbers are entered, and a custom setter in the User model, automatically normalizing numbers when they are set.

Further, a script is added to normalize phone numbers in an existing database. Simply run `flask scripts normalize_phone_numbers` to execute it.

Additionally, update the test database to have valid but still unused phone numbers, as well as one user without a phone number. The old numbers for Monty Python and Rick Astley used the 071 area code, which the phonenumber library doesn't like. The replacement numbers are taken from the [PTS list of phone numbers to use in books, movies, etc](https://www.pts.se/sv/bransch/telefoni/nummer-och-adressering/telefonnummer-for-anvandning-i-bocker-och-filmer-etc/). :)

The purpose of this change is to enable searching for users by phone number, which will be needed for integration with [Sqrubbentelefonen](https://github.com/Sqrubben/Sqrubbentelefonen).