### PR TITLE
fix emma transition, use webm

### DIFF
--- a/flasquelistan/static/css/streque.css
+++ b/flasquelistan/static/css/streque.css
@@ -375,7 +375,7 @@ ol.transaction-history li .value {
   margin-left: 1rem;
 }
 
-#emma-img {
+#emma {
   position: fixed;
   border-radius: 50%;
   top: 50%;
@@ -391,8 +391,7 @@ ol.transaction-history li .value {
   transition: transform .1s;
   transition-timing-function: linear;
 }
-
-#emma-img.hidden {
+#emma.hide-emma {
   transform: translate(-50%, -50%) scale(0.0001);
 }
 

--- a/flasquelistan/static/js/common.js
+++ b/flasquelistan/static/js/common.js
@@ -1,30 +1,38 @@
+function downloadEmma() {
+  var video = document.createElement('video');
+  video.id = 'emma';
+  video.classList.add('hide-emma');
+  video.setAttribute('preload', 'auto');
+  video.setAttribute('muted', '');
+  video.setAttribute('playsinline', '');
+  video.setAttribute('disableRemotePlayback', '');
+
+  var webm = document.createElement('source');
+  webm.src = '/static/images/emma.webm';
+  webm.type = 'video/webm; codecs=vp9';
+  video.appendChild(webm);
+
+  var mp4 = document.createElement('source');
+  mp4.src = '/static/images/emma.compat.mp4';
+  mp4.type = 'video/mp4';
+  video.appendChild(mp4);
+
+  document.body.appendChild(video);
+}
+
 var timeout;
-
 function displayEmma() {
-  if (timeout !== undefined) {
+  if (typeof timeout !== 'undefined') {
     clearTimeout(timeout);
-    document.getElementById('emma-img').remove();
   }
-
-  var emma = document.createElement('img');
-  emma.id = 'emma-img';
-  emma.classList.add('hidden');
-
-  emma.onload = function () {
-    timeout = setTimeout(function () {
-      emma.classList.remove('hidden');
-
-      timeout = setTimeout(function () {
-        emma.classList.add('hidden');
-        setTimeout(function () {
-          emma.remove();
-          timeout = undefined;
-        }, 100);
-      }, 1100);
-    }, 50);
-  };
-  emma.src = '/static/images/emma.gif';
-  document.body.appendChild(emma);
+  var emma = document.getElementById('emma');
+  emma.currentTime = 0;
+  emma.classList.remove('hide-emma');
+  setTimeout(function () { emma.play(); }, 50);
+  timeout = setTimeout(function () {
+    emma.classList.add('hide-emma');
+    emma.pause();
+  }, 1200);
 }
 
 function postData(uri, data, onsuccess, onfailure, csrftoken) {

--- a/flasquelistan/static/js/streque.js
+++ b/flasquelistan/static/js/streque.js
@@ -70,3 +70,4 @@ function addStupidButtons() {
 
 initStrequeButtons();
 addStupidButtons();
+downloadEmma();


### PR DESCRIPTION
Fixes https://github.com/teknologkoren/flasquelistan/issues/111:

* Fixes the transition bug, introduced in commit 7ed304543a7e7db90d1d08afef35dc84c24742b0.
* Reverts commit 27f16b1047819b828c1da108498f31d5ad2003ea while simplifying the implementation a bit. Hopefully browsers are better at doing stuff now.

We replaced webm with gif because of https://github.com/teknologkoren/flasquelistan/issues/60, so someone with an iPhone should probably test if this works. I've tested and confirmed that both video and transition works on Linux+{Firefox,Chrome} and Android+Firefox.